### PR TITLE
Add object ID for S3 (GSI-200)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -4,8 +4,6 @@ s3_endpoint_url: http://localstack:4566
 s3_access_key_id: test
 s3_secret_access_key: test
 permanent_bucket: permanent
-outbox_bucket: outbox
-staging_bucket: staging
 service_instance_id: 001
 kafka_servers: ["kafka:9092"]
 files_to_register_topic: file_interrogation

--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -10,7 +10,7 @@ python -m pip install --upgrade pip
 pip install -e .[all]
 
 # install or upgrade dependencies for development and testing
-pip install --upgrade -r requirements-dev.txt
+pip install -r requirements-dev.txt
 
 # install pre-commit hooks to git
 pre-commit install

--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ ifrs --help
 ### Parameters
 
 The service requires the following configuration parameters:
-- **`outbox_bucket`** *(string)*: The ID of the object storage bucket that is serving as download area.
-
-- **`staging_bucket`** *(string)*: The ID of the object storage bucket that is serving as staging area.
-
 - **`permanent_bucket`** *(string)*: The ID of the object storage bucket that is serving as permanent storage.
 
 - **`file_registered_event_topic`** *(string)*: Name of the topic used for events indicating that a new file has been internally registered.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:0.3.6
+docker pull ghga/internal-file-registry-service:0.4.0
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:0.3.6 .
+docker build -t ghga/internal-file-registry-service:0.4.0 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -55,7 +55,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:0.3.6 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:0.4.0 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/config_schema.json
+++ b/config_schema.json
@@ -3,24 +3,6 @@
   "description": "Modifies the orginal Settings class provided by the user",
   "type": "object",
   "properties": {
-    "outbox_bucket": {
-      "title": "Outbox Bucket",
-      "description": "The ID of the object storage bucket that is serving as download area.",
-      "example": "outbox",
-      "env_names": [
-        "ifrs_outbox_bucket"
-      ],
-      "type": "string"
-    },
-    "staging_bucket": {
-      "title": "Staging Bucket",
-      "description": "The ID of the object storage bucket that is serving as staging area.",
-      "example": "staging",
-      "env_names": [
-        "ifrs_staging_bucket"
-      ],
-      "type": "string"
-    },
     "permanent_bucket": {
       "title": "Permanent Bucket",
       "description": "The ID of the object storage bucket that is serving as permanent storage.",
@@ -241,8 +223,6 @@
     }
   },
   "required": [
-    "outbox_bucket",
-    "staging_bucket",
     "permanent_bucket",
     "file_registered_event_topic",
     "file_registered_event_type",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -15,7 +15,6 @@ files_to_stage_topic: file_downloads
 files_to_stage_type: file_stage_requested
 kafka_servers:
 - kafka:9092
-outbox_bucket: outbox
 permanent_bucket: permanent
 s3_access_key_id: test
 s3_endpoint_url: http://localstack:4566
@@ -23,4 +22,3 @@ s3_secret_access_key: '**********'
 s3_session_token: null
 service_instance_id: '1'
 service_name: internal_file_registry
-staging_bucket: staging

--- a/ifrs/__init__.py
+++ b/ifrs/__init__.py
@@ -15,4 +15,4 @@
 
 """This service acts as a registry for the internal location and representation of files."""
 
-__version__ = "0.3.6"
+__version__ = "0.4.0"

--- a/ifrs/adapters/inbound/event_sub.py
+++ b/ifrs/adapters/inbound/event_sub.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 """Adapter for receiving events providing metadata on files"""
+import uuid
 
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.validation import get_validated_payload
@@ -93,8 +94,11 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileUploadValidationSuccess
         )
 
+        object_id = str(uuid.uuid4())
+
         file = models.FileMetadata(
             file_id=validated_payload.file_id,
+            object_id=object_id,
             decrypted_sha256=validated_payload.decrypted_sha256,
             decrypted_size=validated_payload.decrypted_size,
             upload_date=validated_payload.upload_date,

--- a/ifrs/adapters/inbound/event_sub.py
+++ b/ifrs/adapters/inbound/event_sub.py
@@ -93,7 +93,7 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileUploadValidationSuccess
         )
 
-        file = models.FileMetadataBase(
+        file_without_object_id = models.FileMetadataBase(
             file_id=validated_payload.file_id,
             decrypted_sha256=validated_payload.decrypted_sha256,
             decrypted_size=validated_payload.decrypted_size,
@@ -106,7 +106,7 @@ class EventSubTranslator(EventSubscriberProtocol):
         )
 
         await self._file_registry.register_file(
-            file=file,
+            file_without_object_id=file_without_object_id,
             source_object_id=validated_payload.object_id,
             source_bucket_id=validated_payload.bucket_id,
         )

--- a/ifrs/adapters/inbound/event_sub.py
+++ b/ifrs/adapters/inbound/event_sub.py
@@ -94,6 +94,9 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileUploadValidationSuccess
         )
 
+        source_object_id = validated_payload.source_object_id
+        source_bucket_id = validated_payload.source_bucket_id
+
         object_id = str(uuid.uuid4())
 
         file = models.FileMetadata(
@@ -109,7 +112,11 @@ class EventSubTranslator(EventSubscriberProtocol):
             content_offset=validated_payload.content_offset,
         )
 
-        await self._file_registry.register_file(file=file)
+        await self._file_registry.register_file(
+            file=file,
+            source_object_id=source_object_id,
+            source_bucket_id=source_bucket_id,
+        )
 
     async def _consume_file_downloads(self, *, payload: JsonObject) -> None:
         """Consume file download events."""

--- a/ifrs/adapters/inbound/event_sub.py
+++ b/ifrs/adapters/inbound/event_sub.py
@@ -111,8 +111,8 @@ class EventSubTranslator(EventSubscriberProtocol):
 
         await self._file_registry.register_file(
             file=file,
-            source_object_id=validated_payload.source_object_id,
-            source_bucket_id=validated_payload.source_bucket_id,
+            source_object_id=validated_payload.object_id,
+            source_bucket_id=validated_payload.bucket_id,
         )
 
     async def _consume_file_downloads(self, *, payload: JsonObject) -> None:

--- a/ifrs/adapters/inbound/event_sub.py
+++ b/ifrs/adapters/inbound/event_sub.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 """Adapter for receiving events providing metadata on files"""
-import uuid
 
 from ghga_event_schemas import pydantic_ as event_schemas
 from ghga_event_schemas.validation import get_validated_payload
@@ -94,11 +93,8 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileUploadValidationSuccess
         )
 
-        object_id = str(uuid.uuid4())
-
-        file = models.FileMetadata(
+        file = models.FileMetadataBase(
             file_id=validated_payload.file_id,
-            object_id=object_id,
             decrypted_sha256=validated_payload.decrypted_sha256,
             decrypted_size=validated_payload.decrypted_size,
             upload_date=validated_payload.upload_date,

--- a/ifrs/adapters/inbound/event_sub.py
+++ b/ifrs/adapters/inbound/event_sub.py
@@ -94,9 +94,6 @@ class EventSubTranslator(EventSubscriberProtocol):
             payload=payload, schema=event_schemas.FileUploadValidationSuccess
         )
 
-        source_object_id = validated_payload.source_object_id
-        source_bucket_id = validated_payload.source_bucket_id
-
         object_id = str(uuid.uuid4())
 
         file = models.FileMetadata(
@@ -114,8 +111,8 @@ class EventSubTranslator(EventSubscriberProtocol):
 
         await self._file_registry.register_file(
             file=file,
-            source_object_id=source_object_id,
-            source_bucket_id=source_bucket_id,
+            source_object_id=validated_payload.source_object_id,
+            source_bucket_id=validated_payload.source_bucket_id,
         )
 
     async def _consume_file_downloads(self, *, payload: JsonObject) -> None:
@@ -128,6 +125,8 @@ class EventSubTranslator(EventSubscriberProtocol):
         await self._file_registry.stage_registered_file(
             file_id=validated_payload.file_id,
             decrypted_sha256=validated_payload.decrypted_sha256,
+            target_object_id=validated_payload.target_object_id,
+            target_bucket_id=validated_payload.target_bucket_id,
         )
 
     async def _consume_file_deletions(self, *, payload: JsonObject) -> None:

--- a/ifrs/adapters/outbound/event_pub.py
+++ b/ifrs/adapters/outbound/event_pub.py
@@ -78,11 +78,15 @@ class EventPubTranslator(EventPublisherPort):
         self._config = config
         self._provider = provider
 
-    async def file_internally_registered(self, *, file: models.FileMetadata) -> None:
+    async def file_internally_registered(
+        self, *, file: models.FileMetadata, source_bucket_id: str
+    ) -> None:
         """Communicates the event that a new file has been internally registered."""
 
         payload = event_schemas.FileInternallyRegistered(
             file_id=file.file_id,
+            source_object_id=file.object_id,
+            source_bucket_id=source_bucket_id,
             decrypted_sha256=file.decrypted_sha256,
             decrypted_size=file.decrypted_size,
             decryption_secret_id=file.decryption_secret_id,

--- a/ifrs/adapters/outbound/event_pub.py
+++ b/ifrs/adapters/outbound/event_pub.py
@@ -113,7 +113,7 @@ class EventPubTranslator(EventPublisherPort):
         target_object_id: str,
         target_bucket_id: str,
     ) -> None:
-        """Communicates the event that a new file has been internally registered."""
+        """Communicates the event that a file has been staged for download."""
 
         payload = event_schemas.FileStagedForDownload(
             file_id=file_id,

--- a/ifrs/adapters/outbound/event_pub.py
+++ b/ifrs/adapters/outbound/event_pub.py
@@ -106,13 +106,20 @@ class EventPubTranslator(EventPublisherPort):
         )
 
     async def file_staged_for_download(
-        self, *, file_id: str, decrypted_sha256: str
+        self,
+        *,
+        file_id: str,
+        decrypted_sha256: str,
+        target_object_id: str,
+        target_bucket_id: str,
     ) -> None:
         """Communicates the event that a new file has been internally registered."""
 
         payload = event_schemas.FileStagedForDownload(
             file_id=file_id,
             decrypted_sha256=decrypted_sha256,
+            target_object_id=target_object_id,
+            target_bucket_id=target_bucket_id,
         )
         payload_dict = json.loads(payload.json())
 

--- a/ifrs/adapters/outbound/event_pub.py
+++ b/ifrs/adapters/outbound/event_pub.py
@@ -79,14 +79,14 @@ class EventPubTranslator(EventPublisherPort):
         self._provider = provider
 
     async def file_internally_registered(
-        self, *, file: models.FileMetadata, source_bucket_id: str
+        self, *, file: models.FileMetadata, bucket_id: str
     ) -> None:
         """Communicates the event that a new file has been internally registered."""
 
         payload = event_schemas.FileInternallyRegistered(
             file_id=file.file_id,
             object_id=file.object_id,
-            bucket_id=source_bucket_id,
+            bucket_id=bucket_id,
             decrypted_sha256=file.decrypted_sha256,
             decrypted_size=file.decrypted_size,
             decryption_secret_id=file.decryption_secret_id,

--- a/ifrs/adapters/outbound/event_pub.py
+++ b/ifrs/adapters/outbound/event_pub.py
@@ -85,8 +85,8 @@ class EventPubTranslator(EventPublisherPort):
 
         payload = event_schemas.FileInternallyRegistered(
             file_id=file.file_id,
-            source_object_id=file.object_id,
-            source_bucket_id=source_bucket_id,
+            object_id=file.object_id,
+            bucket_id=source_bucket_id,
             decrypted_sha256=file.decrypted_sha256,
             decrypted_size=file.decrypted_size,
             decryption_secret_id=file.decryption_secret_id,

--- a/ifrs/core/content_copy.py
+++ b/ifrs/core/content_copy.py
@@ -23,7 +23,7 @@ from ifrs.ports.outbound.storage import ObjectStoragePort
 
 
 class StorageEnitiesConfig(BaseSettings):
-    """A config for specifying the location of permanent storage"""
+    """A config for specifying the location of major storage entities."""
 
     permanent_bucket: str = Field(
         ...,

--- a/ifrs/core/content_copy.py
+++ b/ifrs/core/content_copy.py
@@ -23,22 +23,8 @@ from ifrs.ports.outbound.storage import ObjectStoragePort
 
 
 class StorageEnitiesConfig(BaseSettings):
-    """A config for specifying the location of the major storage enities."""
+    """A config for specifying the location of permanent storage"""
 
-    outbox_bucket: str = Field(
-        ...,
-        description=(
-            "The ID of the object storage bucket that is serving as download area."
-        ),
-        example="outbox",
-    )
-    staging_bucket: str = Field(
-        ...,
-        description=(
-            "The ID of the object storage bucket that is serving as staging area."
-        ),
-        example="staging",
-    )
     permanent_bucket: str = Field(
         ...,
         description=(

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -62,7 +62,9 @@ class FileRegistry(FileRegistryPort):
 
         raise self.FileUpdateError(file_id=file.file_id)
 
-    async def register_file(self, *, file: models.FileMetadata) -> None:
+    async def register_file(
+        self, *, file: models.FileMetadata, source_object_id: str, source_bucket_id: str
+    ) -> None:
         """Registers a file and moves its content from the staging into the permanent
         storage. If the file with that exact metadata has already been registered,
         nothing is done.
@@ -83,7 +85,11 @@ class FileRegistry(FileRegistryPort):
             return
 
         try:
-            await self._content_copy_svc.staging_to_permanent(file=file)
+            await self._content_copy_svc.staging_to_permanent(
+                file=file,
+                source_object_id=source_object_id,
+                source_bucket_id=source_bucket_id,
+            )
         except IContentCopyService.ContentNotInstagingError as error:
             raise self.FileContentNotInstagingError(file_id=file.file_id) from error
 

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -44,7 +44,7 @@ class FileRegistry(FileRegistryPort):
         self._object_storage = object_storage
         self._config = config
 
-    async def _is_file_registered(self, *, file: models.FileMetadata) -> bool:
+    async def _is_file_registered(self, *, file: models.FileMetadataBase) -> bool:
         """Checks if the specified file is already registered. There are three possible
         outcomes:
             - Yes, the file has been registered with metadata that is identical to the

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -59,10 +59,9 @@ class FileRegistry(FileRegistryPort):
             return False
 
         # object ID is a UUID generated upon registration, so cannot compare those
-        file_without_object_id = file.dict(exclude={"object_id"})
         registered_file_without_object_id = registered_file.dict(exclude={"object_id"})
 
-        if file_without_object_id == registered_file_without_object_id:
+        if file == registered_file_without_object_id:
             return True
 
         raise self.FileUpdateError(file_id=file.file_id)

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -97,9 +97,10 @@ class FileRegistry(FileRegistryPort):
             # There is nothing to do:
             return
 
+        # Generate & assign object ID to metadata
         object_id = str(uuid.uuid4())
-
         file_with_object_id = models.FileMetadata(**file.dict(), object_id=object_id)
+
         try:
             await self._content_copy_svc.staging_to_permanent(
                 file=file_with_object_id,

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -71,6 +71,10 @@ class FileRegistry(FileRegistryPort):
 
         Args:
             file: metadata on the file to register.
+            source_object_id:
+                The S3 object ID for the staging bucket.
+            source_bucket_id:
+                The S3 bucket ID for staging.
 
         Raises:
             self.FileUpdateError:

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -98,7 +98,12 @@ class FileRegistry(FileRegistryPort):
         await self._event_publisher.file_internally_registered(file=file)
 
     async def stage_registered_file(
-        self, *, file_id: str, decrypted_sha256: str
+        self,
+        *,
+        file_id: str,
+        decrypted_sha256: str,
+        target_object_id: str,
+        target_bucket_id: str,
     ) -> None:
         """Stage a registered file to the outbox.
 
@@ -108,6 +113,10 @@ class FileRegistry(FileRegistryPort):
             decrypted_sha256:
                 The checksum of the decrypted content. This is used to make sure that
                 this service and the outside client are talking about the same file.
+            target_object_id:
+                The S3 object ID for the outbox bucket.
+            target_bucket_id:
+                The S3 bucket ID for the outbox.
 
         Raises:
             self.FileNotInRegistryError:
@@ -133,7 +142,11 @@ class FileRegistry(FileRegistryPort):
             )
 
         try:
-            await self._content_copy_svc.permanent_to_outbox(file=file)
+            await self._content_copy_svc.permanent_to_outbox(
+                file=file,
+                target_object_id=target_object_id,
+                target_bucket_id=target_bucket_id,
+            )
 
             await self._event_publisher.file_staged_for_download(
                 file_id=file_id, decrypted_sha256=decrypted_sha256

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -99,7 +99,9 @@ class FileRegistry(FileRegistryPort):
 
         await self._file_metadata_dao.insert(file)
 
-        await self._event_publisher.file_internally_registered(file=file)
+        await self._event_publisher.file_internally_registered(
+            file=file, source_bucket_id=self._config.permanent_bucket
+        )
 
     async def stage_registered_file(
         self,

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -155,7 +155,10 @@ class FileRegistry(FileRegistryPort):
             )
 
             await self._event_publisher.file_staged_for_download(
-                file_id=file_id, decrypted_sha256=decrypted_sha256
+                file_id=file_id,
+                decrypted_sha256=decrypted_sha256,
+                target_object_id=target_object_id,
+                target_bucket_id=target_bucket_id,
             )
 
         except IContentCopyService.ContentNotInPermanentStorageError as error:

--- a/ifrs/core/file_registry.py
+++ b/ifrs/core/file_registry.py
@@ -146,8 +146,12 @@ class FileRegistry(FileRegistryPort):
 
         # Try to remove file from S3
         try:
+            # Get object ID
+            file = await self._file_metadata_dao.get_by_id(file_id)
+            object_id = file.object_id
+
             await self._object_storage.delete_object(
-                bucket_id=self._config.permanent_bucket, object_id=file_id
+                bucket_id=self._config.permanent_bucket, object_id=object_id
             )
 
         except self._object_storage.ObjectNotFoundError:

--- a/ifrs/core/interfaces.py
+++ b/ifrs/core/interfaces.py
@@ -53,6 +53,8 @@ class IContentCopyService(ABC):
         ...
 
     @abstractmethod
-    async def permanent_to_outbox(self, *, file: models.FileMetadata) -> None:
+    async def permanent_to_outbox(
+        self, *, file: models.FileMetadata, target_object_id: str, target_bucket_id: str
+    ) -> None:
         """Copy a file from an staging stage to the permanent storage."""
         ...

--- a/ifrs/core/interfaces.py
+++ b/ifrs/core/interfaces.py
@@ -46,7 +46,9 @@ class IContentCopyService(ABC):
             super().__init__(message)
 
     @abstractmethod
-    async def staging_to_permanent(self, *, file: models.FileMetadata) -> None:
+    async def staging_to_permanent(
+        self, *, file: models.FileMetadata, source_object_id: str, source_bucket_id: str
+    ) -> None:
         """Copy a file from an staging stage to the permanent storage."""
         ...
 

--- a/ifrs/core/models.py
+++ b/ifrs/core/models.py
@@ -26,6 +26,7 @@ class FileMetadata(BaseModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
+    object_id: str = Field(..., description="The S3-specific ID for a given bucket.")
     upload_date: str = Field(
         ...,
         description="The date and time when this file was ingested into the system.",

--- a/ifrs/core/models.py
+++ b/ifrs/core/models.py
@@ -78,6 +78,8 @@ class FileMetadataBase(BaseModel):
 
 
 class FileMetadata(FileMetadataBase):
-    """The file metadata plus a generated S3 object ID"""
+    """The file metadata plus a object storage ID generated upon registration"""
 
-    object_id: str
+    object_id: str = Field(
+        ..., description="A UUID to identify the file in object storage"
+    )

--- a/ifrs/core/models.py
+++ b/ifrs/core/models.py
@@ -18,7 +18,7 @@
 from pydantic import BaseModel, Field
 
 
-class FileMetadata(BaseModel):
+class FileMetadataBase(BaseModel):
     """
     A model containing metadata on a registered file.
     """
@@ -26,7 +26,6 @@ class FileMetadata(BaseModel):
     file_id: str = Field(
         ..., description="The public ID of the file as present in the metadata catalog."
     )
-    object_id: str = Field(..., description="The S3-specific ID for a given bucket.")
     upload_date: str = Field(
         ...,
         description="The date and time when this file was ingested into the system.",
@@ -76,3 +75,9 @@ class FileMetadata(BaseModel):
         ...,
         description="The SHA-256 checksum of the entire decrypted file content.",
     )
+
+
+class FileMetadata(FileMetadataBase):
+    """The file metadata plus a generated S3 object ID"""
+
+    object_id: str

--- a/ifrs/ports/inbound/file_registry.py
+++ b/ifrs/ports/inbound/file_registry.py
@@ -94,7 +94,11 @@ class FileRegistryPort(ABC):
 
     @abstractmethod
     async def register_file(
-        self, *, file: models.FileMetadata, source_object_id: str, source_bucket_id: str
+        self,
+        *,
+        file: models.FileMetadataBase,
+        source_object_id: str,
+        source_bucket_id: str,
     ) -> None:
         """Registers a file and moves its content from the staging into the permanent
         storage. If the file with that exact metadata has already been registered,

--- a/ifrs/ports/inbound/file_registry.py
+++ b/ifrs/ports/inbound/file_registry.py
@@ -93,7 +93,9 @@ class FileRegistryPort(ABC):
             super().__init__(message)
 
     @abstractmethod
-    async def register_file(self, *, file: models.FileMetadata) -> None:
+    async def register_file(
+        self, *, file: models.FileMetadata, source_object_id: str, source_bucket_id: str
+    ) -> None:
         """Registers a file and moves its content from the staging into the permanent
         storage. If the file with that exact metadata has already been registered,
         nothing is done.

--- a/ifrs/ports/inbound/file_registry.py
+++ b/ifrs/ports/inbound/file_registry.py
@@ -96,7 +96,7 @@ class FileRegistryPort(ABC):
     async def register_file(
         self,
         *,
-        file: models.FileMetadataBase,
+        file_without_object_id: models.FileMetadataBase,
         source_object_id: str,
         source_bucket_id: str,
     ) -> None:
@@ -105,7 +105,7 @@ class FileRegistryPort(ABC):
         nothing is done.
 
         Args:
-            file: metadata on the file to register.
+            file_without_object_id: metadata on the file to register.
             source_object_id:
                 The S3 object ID for the staging bucket.
             source_bucket_id:

--- a/ifrs/ports/inbound/file_registry.py
+++ b/ifrs/ports/inbound/file_registry.py
@@ -102,6 +102,10 @@ class FileRegistryPort(ABC):
 
         Args:
             file: metadata on the file to register.
+            source_object_id:
+                The S3 object ID for the staging bucket.
+            source_bucket_id:
+                The S3 bucket ID for staging.
 
         Raises:
             self.FileUpdateError:

--- a/ifrs/ports/inbound/file_registry.py
+++ b/ifrs/ports/inbound/file_registry.py
@@ -114,7 +114,12 @@ class FileRegistryPort(ABC):
 
     @abstractmethod
     async def stage_registered_file(
-        self, *, file_id: str, decrypted_sha256: str
+        self,
+        *,
+        file_id: str,
+        decrypted_sha256: str,
+        target_object_id: str,
+        target_bucket_id: str,
     ) -> None:
         """Stage a registered file to the outbox.
 
@@ -124,6 +129,10 @@ class FileRegistryPort(ABC):
             decrypted_sha256:
                 The checksum of the decrypted content. This is used to make sure that
                 this service and the outside client are talking about the same file.
+            target_object_id:
+                The S3 object ID for the outbox bucket.
+            target_bucket_id:
+                The S3 bucket ID for the outbox.
 
         Raises:
             self.FileNotInRegistryError:

--- a/ifrs/ports/outbound/event_pub.py
+++ b/ifrs/ports/outbound/event_pub.py
@@ -25,7 +25,7 @@ class EventPublisherPort(ABC):
 
     @abstractmethod
     async def file_internally_registered(
-        self, *, file: models.FileMetadata, source_bucket_id: str
+        self, *, file: models.FileMetadata, bucket_id: str
     ) -> None:
         """Communicates the event that a new file has been internally registered."""
         ...

--- a/ifrs/ports/outbound/event_pub.py
+++ b/ifrs/ports/outbound/event_pub.py
@@ -24,7 +24,9 @@ class EventPublisherPort(ABC):
     """A port through which service-internal events are communicated with the outside."""
 
     @abstractmethod
-    async def file_internally_registered(self, *, file: models.FileMetadata) -> None:
+    async def file_internally_registered(
+        self, *, file: models.FileMetadata, source_bucket_id: str
+    ) -> None:
         """Communicates the event that a new file has been internally registered."""
         ...
 

--- a/ifrs/ports/outbound/event_pub.py
+++ b/ifrs/ports/outbound/event_pub.py
@@ -32,7 +32,12 @@ class EventPublisherPort(ABC):
 
     @abstractmethod
     async def file_staged_for_download(
-        self, *, file_id: str, decrypted_sha256: str
+        self,
+        *,
+        file_id: str,
+        decrypted_sha256: str,
+        target_object_id: str,
+        target_bucket_id: str
     ) -> None:
         """Communicates the event that a file has been staged for download"""
         ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    ghga-event-schemas==0.11.0
+    ghga-event-schemas==0.13.0
     hexkit[mongodb,s3,akafka]==0.10.0
 python_requires = >= 3.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    ghga-event-schemas==0.13.0
+    ghga-event-schemas==0.13.1
     hexkit[mongodb,s3,akafka]==0.10.0
 python_requires = >= 3.9
 

--- a/tests/fixtures/example_data.py
+++ b/tests/fixtures/example_data.py
@@ -21,6 +21,7 @@ from ifrs.core import models
 
 EXAMPLE_FILE = models.FileMetadata(
     file_id="examplefile001",
+    object_id="objectid001",
     upload_date=datetime.utcnow().isoformat(),
     decryption_secret_id="some-secret-id",
     decrypted_size=64 * 1024**2,

--- a/tests/fixtures/example_data.py
+++ b/tests/fixtures/example_data.py
@@ -19,9 +19,8 @@ from datetime import datetime
 
 from ifrs.core import models
 
-EXAMPLE_FILE = models.FileMetadata(
+EXAMPLE_METADATA_BASE = models.FileMetadataBase(
     file_id="examplefile001",
-    object_id="objectid001",
     upload_date=datetime.utcnow().isoformat(),
     decryption_secret_id="some-secret-id",
     decrypted_size=64 * 1024**2,
@@ -39,4 +38,8 @@ EXAMPLE_FILE = models.FileMetadata(
         "62c298fd987a6bac2066e4dbed274879247b3edd816c8351dc22ada6d37b24b0",
         "45cccbdfc4bfe2aa7f17428a087282d71be917ef059cac15a161284340840957",
     ],
+)
+
+EXAMPLE_METADATA = models.FileMetadata(
+    **EXAMPLE_METADATA_BASE.dict(), object_id="objectid001"
 )

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -38,6 +38,9 @@ from ifrs.container import Container
 from ifrs.main import get_configured_container
 from tests.fixtures.config import get_config
 
+OUTBOX_BUCKET = "outbox"
+STAGING_BUCKET = "staging"
+
 
 def get_free_port() -> int:
     """Finds and returns a free port on localhost."""
@@ -55,6 +58,8 @@ class JointFixture:
     mongodb: MongoDbFixture
     s3: S3Fixture
     kafka: KafkaFixture
+    outbox_bucket: str
+    staging_bucket: str
 
 
 @pytest_asyncio.fixture
@@ -73,8 +78,8 @@ async def joint_fixture(
         # create storage entities:
         await s3_fixture.populate_buckets(
             buckets=[
-                config.outbox_bucket,
-                config.staging_bucket,
+                OUTBOX_BUCKET,
+                STAGING_BUCKET,
                 config.permanent_bucket,
             ]
         )
@@ -85,4 +90,6 @@ async def joint_fixture(
             mongodb=mongodb_fixture,
             s3=s3_fixture,
             kafka=kafka_fixture,
+            outbox_bucket=OUTBOX_BUCKET,
+            staging_bucket=STAGING_BUCKET,
         )

--- a/tests/fixtures/test_config.yaml
+++ b/tests/fixtures/test_config.yaml
@@ -6,8 +6,6 @@ service_name: ifrs
 db_connection_str: "mongodb://mongodb:27017"
 db_name: "dev_db"
 permanent_bucket: permanent
-outbox_bucket: outbox
-staging_bucket: staging
 service_instance_id: 001
 kafka_servers: ["kafka:9092"]
 files_to_register_topic: file_interrogation

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -108,8 +108,6 @@ async def test_reregistration_with_updated_metadata(
     # register new file from the staging:
     # (And check if an event informing about the new registration has been published.)
     file_registry = await joint_fixture.container.file_registry()
-    event_details = EXAMPLE_METADATA_BASE.dict()
-    event_details["bucket_id"] = joint_fixture.config.permanent_bucket
 
     async with joint_fixture.kafka.record_events(
         in_topic=joint_fixture.config.file_registered_event_topic,

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -63,8 +63,8 @@ async def test_reregistration(
     file_registry = await joint_fixture.container.file_registry()
 
     event_details = EXAMPLE_FILE.dict()
-    event_details["source_object_id"] = event_details.pop("object_id")
-    event_details["source_bucket_id"] = joint_fixture.config.permanent_bucket
+    event_details["object_id"] = event_details.pop("object_id")
+    event_details["bucket_id"] = joint_fixture.config.permanent_bucket
     async with joint_fixture.kafka.expect_events(
         events=[
             ExpectedEvent(
@@ -114,8 +114,8 @@ async def test_reregistration_with_updated_metadata(
     # (And check if an event informing about the new registration has been published.)
     file_registry = await joint_fixture.container.file_registry()
     event_details = EXAMPLE_FILE.dict()
-    event_details["source_object_id"] = event_details.pop("object_id")
-    event_details["source_bucket_id"] = joint_fixture.config.permanent_bucket
+    event_details["object_id"] = event_details.pop("object_id")
+    event_details["bucket_id"] = joint_fixture.config.permanent_bucket
 
     async with joint_fixture.kafka.expect_events(
         events=[

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -34,7 +34,7 @@ async def test_register_with_empty_staging(
     file_registry = await joint_fixture.container.file_registry()
     with pytest.raises(FileRegistryPort.FileContentNotInstagingError):
         await file_registry.register_file(
-            file=EXAMPLE_METADATA_BASE,
+            file_without_object_id=EXAMPLE_METADATA_BASE,
             source_object_id="missing",
             source_bucket_id=joint_fixture.staging_bucket,
         )
@@ -65,7 +65,7 @@ async def test_reregistration(
         in_topic=joint_fixture.config.file_registered_event_topic
     ) as recorder:
         await file_registry.register_file(
-            file=EXAMPLE_METADATA_BASE,
+            file_without_object_id=EXAMPLE_METADATA_BASE,
             source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )
@@ -82,7 +82,7 @@ async def test_reregistration(
         in_topic=joint_fixture.config.file_registered_event_topic,
     ):
         await file_registry.register_file(
-            file=EXAMPLE_METADATA_BASE,
+            file_without_object_id=EXAMPLE_METADATA_BASE,
             source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )
@@ -113,7 +113,7 @@ async def test_reregistration_with_updated_metadata(
         in_topic=joint_fixture.config.file_registered_event_topic,
     ) as recorder:
         await file_registry.register_file(
-            file=EXAMPLE_METADATA_BASE,
+            file_without_object_id=EXAMPLE_METADATA_BASE,
             source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )
@@ -132,7 +132,7 @@ async def test_reregistration_with_updated_metadata(
     ):
         with pytest.raises(FileRegistryPort.FileUpdateError):
             await file_registry.register_file(
-                file=file_update,
+                file_without_object_id=file_update,
                 source_object_id=EXAMPLE_METADATA.object_id,
                 source_bucket_id=joint_fixture.staging_bucket,
             )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -17,12 +17,11 @@
 
 
 import pytest
-from hexkit.providers.akafka.testutils import ExpectedEvent
 from hexkit.providers.s3.testutils import file_fixture  # noqa: F401
 from hexkit.providers.s3.testutils import FileObject
 
 from ifrs.ports.inbound.file_registry import FileRegistryPort
-from tests.fixtures.example_data import EXAMPLE_FILE
+from tests.fixtures.example_data import EXAMPLE_METADATA, EXAMPLE_METADATA_BASE
 from tests.fixtures.joint import *  # noqa: F403
 
 
@@ -35,7 +34,7 @@ async def test_register_with_empty_staging(
     file_registry = await joint_fixture.container.file_registry()
     with pytest.raises(FileRegistryPort.FileContentNotInstagingError):
         await file_registry.register_file(
-            file=EXAMPLE_FILE,
+            file=EXAMPLE_METADATA_BASE,
             source_object_id="missing",
             source_bucket_id=joint_fixture.staging_bucket,
         )
@@ -53,7 +52,7 @@ async def test_reregistration(
     file_object = file_fixture.copy(
         update={
             "bucket_id": joint_fixture.staging_bucket,
-            "object_id": EXAMPLE_FILE.object_id,
+            "object_id": EXAMPLE_METADATA.object_id,
         }
     )
     await joint_fixture.s3.populate_file_objects(file_objects=[file_object])
@@ -62,23 +61,19 @@ async def test_reregistration(
     # (And check if an event informing about the new registration has been published.)
     file_registry = await joint_fixture.container.file_registry()
 
-    event_details = EXAMPLE_FILE.dict()
-    event_details["object_id"] = event_details.pop("object_id")
-    event_details["bucket_id"] = joint_fixture.config.permanent_bucket
-    async with joint_fixture.kafka.expect_events(
-        events=[
-            ExpectedEvent(
-                payload=event_details,
-                type_=joint_fixture.config.file_registered_event_type,
-            )
-        ],
-        in_topic=joint_fixture.config.file_registered_event_topic,
-    ):
+    async with joint_fixture.kafka.record_events(
+        in_topic=joint_fixture.config.file_registered_event_topic
+    ) as recorder:
         await file_registry.register_file(
-            file=EXAMPLE_FILE,
-            source_object_id=EXAMPLE_FILE.object_id,
+            file=EXAMPLE_METADATA_BASE,
+            source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )
+
+    assert len(recorder.recorded_events) == 1
+    event = recorder.recorded_events[0]
+    assert event.payload["object_id"] != ""
+    assert event.type_ == joint_fixture.config.file_registered_event_type
 
     # re-register the same file from the staging:
     # (A second event is not expected.)
@@ -87,8 +82,8 @@ async def test_reregistration(
         in_topic=joint_fixture.config.file_registered_event_topic,
     ):
         await file_registry.register_file(
-            file=EXAMPLE_FILE,
-            source_object_id=EXAMPLE_FILE.object_id,
+            file=EXAMPLE_METADATA_BASE,
+            source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )
 
@@ -105,7 +100,7 @@ async def test_reregistration_with_updated_metadata(
     file_object = file_fixture.copy(
         update={
             "bucket_id": joint_fixture.staging_bucket,
-            "object_id": EXAMPLE_FILE.object_id,
+            "object_id": EXAMPLE_METADATA.object_id,
         }
     )
     await joint_fixture.s3.populate_file_objects(file_objects=[file_object])
@@ -113,28 +108,26 @@ async def test_reregistration_with_updated_metadata(
     # register new file from the staging:
     # (And check if an event informing about the new registration has been published.)
     file_registry = await joint_fixture.container.file_registry()
-    event_details = EXAMPLE_FILE.dict()
-    event_details["object_id"] = event_details.pop("object_id")
+    event_details = EXAMPLE_METADATA_BASE.dict()
     event_details["bucket_id"] = joint_fixture.config.permanent_bucket
 
-    async with joint_fixture.kafka.expect_events(
-        events=[
-            ExpectedEvent(
-                payload=event_details,
-                type_=joint_fixture.config.file_registered_event_type,
-            )
-        ],
+    async with joint_fixture.kafka.record_events(
         in_topic=joint_fixture.config.file_registered_event_topic,
-    ):
+    ) as recorder:
         await file_registry.register_file(
-            file=EXAMPLE_FILE,
-            source_object_id=EXAMPLE_FILE.object_id,
+            file=EXAMPLE_METADATA_BASE,
+            source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )
 
+    assert len(recorder.recorded_events) == 1
+    event = recorder.recorded_events[0]
+    assert event.payload["object_id"] != ""
+    assert event.type_ == joint_fixture.config.file_registered_event_type
+
     # try to re-register the same file with updated metadata:
     # (Expect an exception and no second event.)
-    file_update = EXAMPLE_FILE.copy(update={"decrypted_size": 4321})
+    file_update = EXAMPLE_METADATA_BASE.copy(update={"decrypted_size": 4321})
     async with joint_fixture.kafka.expect_events(
         events=[],
         in_topic=joint_fixture.config.file_registered_event_topic,
@@ -142,7 +135,7 @@ async def test_reregistration_with_updated_metadata(
         with pytest.raises(FileRegistryPort.FileUpdateError):
             await file_registry.register_file(
                 file=file_update,
-                source_object_id=EXAMPLE_FILE.object_id,
+                source_object_id=EXAMPLE_METADATA.object_id,
                 source_bucket_id=joint_fixture.staging_bucket,
             )
 
@@ -156,8 +149,8 @@ async def test_stage_non_existing_file(joint_fixture: JointFixture):  # noqa: F8
     with pytest.raises(FileRegistryPort.FileNotInRegistryError):
         await file_registry.stage_registered_file(
             file_id="notregisteredfile001",
-            decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,
-            target_object_id=EXAMPLE_FILE.object_id,
+            decrypted_sha256=EXAMPLE_METADATA_BASE.decrypted_sha256,
+            target_object_id=EXAMPLE_METADATA.object_id,
             target_bucket_id=joint_fixture.outbox_bucket,
         )
 
@@ -174,24 +167,24 @@ async def test_stage_checksum_missmatch(
     file_object = file_fixture.copy(
         update={
             "bucket_id": joint_fixture.staging_bucket,
-            "object_id": EXAMPLE_FILE.object_id,
+            "object_id": EXAMPLE_METADATA.object_id,
         }
     )
     await joint_fixture.s3.populate_file_objects(file_objects=[file_object])
 
     # populate the database with a corresponding file metadata entry:
     file_metadata_dao = await joint_fixture.container.file_metadata_dao()
-    await file_metadata_dao.insert(EXAMPLE_FILE)
+    await file_metadata_dao.insert(EXAMPLE_METADATA)
 
     # request a stage for the registered file by specifying a wrong checksum:
     file_registry = await joint_fixture.container.file_registry()
     with pytest.raises(FileRegistryPort.ChecksumMissmatchError):
         await file_registry.stage_registered_file(
-            file_id=EXAMPLE_FILE.file_id,
+            file_id=EXAMPLE_METADATA_BASE.file_id,
             decrypted_sha256=(
                 "e6da6d6d05cc057964877aad8a3e9ad712c8abeae279dfa2f89b07eba7ef8abe"
             ),
-            target_object_id=EXAMPLE_FILE.object_id,
+            target_object_id=EXAMPLE_METADATA.object_id,
             target_bucket_id=joint_fixture.staging_bucket,
         )
 
@@ -207,14 +200,14 @@ async def test_storage_db_inconsistency(
     # populate the database with metadata on an example file even though the storage is
     # empty:
     file_metadata_dao = await joint_fixture.container.file_metadata_dao()
-    await file_metadata_dao.insert(EXAMPLE_FILE)
+    await file_metadata_dao.insert(EXAMPLE_METADATA)
 
     # request a stage for the registered file by specifying a wrong checksum:
     file_registry = await joint_fixture.container.file_registry()
     with pytest.raises(FileRegistryPort.FileInRegistryButNotInStorageError):
         await file_registry.stage_registered_file(
-            file_id=EXAMPLE_FILE.file_id,
-            decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,
-            target_object_id=EXAMPLE_FILE.object_id,
+            file_id=EXAMPLE_METADATA_BASE.file_id,
+            decrypted_sha256=EXAMPLE_METADATA_BASE.decrypted_sha256,
+            target_object_id=EXAMPLE_METADATA.object_id,
             target_bucket_id=joint_fixture.staging_bucket,
         )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -158,13 +158,13 @@ async def test_stage_checksum_missmatch(
     joint_fixture: JointFixture,  # noqa: F811, F405
     file_fixture: FileObject,  # noqa: F811
 ):
-    """Check that requesting to stage a registered file by specifying the wrong checksum
-    fails with the expected exception."""
+    """Check that requesting to stage a registered file to the outbox by specifying the
+    wrong checksum fails with the expected exception."""
 
     # place the content for an example file in the permanent storage:
     file_object = file_fixture.copy(
         update={
-            "bucket_id": joint_fixture.staging_bucket,
+            "bucket_id": joint_fixture.config.permanent_bucket,
             "object_id": EXAMPLE_METADATA.object_id,
         }
     )
@@ -174,7 +174,7 @@ async def test_stage_checksum_missmatch(
     file_metadata_dao = await joint_fixture.container.file_metadata_dao()
     await file_metadata_dao.insert(EXAMPLE_METADATA)
 
-    # request a stage for the registered file by specifying a wrong checksum:
+    # request a stage for the registered file to the outbox by specifying a wrong checksum:
     file_registry = await joint_fixture.container.file_registry()
     with pytest.raises(FileRegistryPort.ChecksumMissmatchError):
         await file_registry.stage_registered_file(
@@ -183,7 +183,7 @@ async def test_stage_checksum_missmatch(
                 "e6da6d6d05cc057964877aad8a3e9ad712c8abeae279dfa2f89b07eba7ef8abe"
             ),
             target_object_id=EXAMPLE_METADATA.object_id,
-            target_bucket_id=joint_fixture.staging_bucket,
+            target_bucket_id=joint_fixture.outbox_bucket,
         )
 
 
@@ -207,5 +207,5 @@ async def test_storage_db_inconsistency(
             file_id=EXAMPLE_METADATA_BASE.file_id,
             decrypted_sha256=EXAMPLE_METADATA_BASE.decrypted_sha256,
             target_object_id=EXAMPLE_METADATA.object_id,
-            target_bucket_id=joint_fixture.staging_bucket,
+            target_bucket_id=joint_fixture.outbox_bucket,
         )

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -46,8 +46,8 @@ async def test_happy_journey(
     file_registry = await joint_fixture.container.file_registry()
 
     event_details = EXAMPLE_FILE.dict()
-    event_details["source_object_id"] = event_details.pop("object_id")
-    event_details["source_bucket_id"] = joint_fixture.config.permanent_bucket
+    event_details["object_id"] = event_details.pop("object_id")
+    event_details["bucket_id"] = joint_fixture.config.permanent_bucket
     async with joint_fixture.kafka.expect_events(
         events=[
             ExpectedEvent(

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -49,7 +49,7 @@ async def test_happy_journey(
         in_topic=joint_fixture.config.file_registered_event_topic,
     ) as recorder:
         await file_registry.register_file(
-            file=EXAMPLE_METADATA_BASE,
+            file_without_object_id=EXAMPLE_METADATA_BASE,
             source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -21,7 +21,7 @@ from hexkit.providers.akafka.testutils import ExpectedEvent
 from hexkit.providers.s3.testutils import file_fixture  # noqa: F401
 from hexkit.providers.s3.testutils import FileObject
 
-from tests.fixtures.example_data import EXAMPLE_FILE
+from tests.fixtures.example_data import EXAMPLE_METADATA, EXAMPLE_METADATA_BASE
 from tests.fixtures.joint import *  # noqa: F403
 
 
@@ -36,7 +36,7 @@ async def test_happy_journey(
     file_object = file_fixture.copy(
         update={
             "bucket_id": joint_fixture.staging_bucket,
-            "object_id": EXAMPLE_FILE.object_id,
+            "object_id": EXAMPLE_METADATA.object_id,
         }
     )
     await joint_fixture.s3.populate_file_objects(file_objects=[file_object])
@@ -45,31 +45,30 @@ async def test_happy_journey(
     # (And check if an event informing about the new registration has been published.)
     file_registry = await joint_fixture.container.file_registry()
 
-    event_details = EXAMPLE_FILE.dict()
-    event_details["object_id"] = event_details.pop("object_id")
-    event_details["bucket_id"] = joint_fixture.config.permanent_bucket
-    async with joint_fixture.kafka.expect_events(
-        events=[
-            ExpectedEvent(
-                payload=event_details,
-                type_=joint_fixture.config.file_registered_event_type,
-            )
-        ],
+    async with joint_fixture.kafka.record_events(
         in_topic=joint_fixture.config.file_registered_event_topic,
-    ):
+    ) as recorder:
         await file_registry.register_file(
-            file=EXAMPLE_FILE,
-            source_object_id=EXAMPLE_FILE.object_id,
+            file=EXAMPLE_METADATA_BASE,
+            source_object_id=EXAMPLE_METADATA.object_id,
             source_bucket_id=joint_fixture.staging_bucket,
         )
 
+    assert len(recorder.recorded_events) == 1
+    event = recorder.recorded_events[0]
+    assert event.payload["object_id"] != ""
+    assert event.type_ == joint_fixture.config.file_registered_event_type
+
+    object_id = event.payload["object_id"]
+
     # check that the file content is now in both the staging and the permanent storage:
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.staging_bucket, object_id=EXAMPLE_FILE.object_id
+        bucket_id=joint_fixture.staging_bucket,
+        object_id=EXAMPLE_METADATA.object_id,
     )
     assert await joint_fixture.s3.storage.does_object_exist(
         bucket_id=joint_fixture.config.permanent_bucket,
-        object_id=EXAMPLE_FILE.object_id,
+        object_id=object_id,
     )
 
     # request a stage to the outbox:
@@ -77,9 +76,9 @@ async def test_happy_journey(
         events=[
             ExpectedEvent(
                 payload={
-                    "file_id": EXAMPLE_FILE.file_id,
-                    "decrypted_sha256": EXAMPLE_FILE.decrypted_sha256,
-                    "target_object_id": EXAMPLE_FILE.object_id,
+                    "file_id": EXAMPLE_METADATA_BASE.file_id,
+                    "decrypted_sha256": EXAMPLE_METADATA_BASE.decrypted_sha256,
+                    "target_object_id": EXAMPLE_METADATA.object_id,
                     "target_bucket_id": joint_fixture.outbox_bucket,
                 },
                 type_=joint_fixture.config.file_staged_event_type,
@@ -88,30 +87,31 @@ async def test_happy_journey(
         in_topic=joint_fixture.config.file_staged_event_topic,
     ):
         await file_registry.stage_registered_file(
-            file_id=EXAMPLE_FILE.file_id,
-            decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,
-            target_object_id=EXAMPLE_FILE.object_id,
+            file_id=EXAMPLE_METADATA_BASE.file_id,
+            decrypted_sha256=EXAMPLE_METADATA_BASE.decrypted_sha256,
+            target_object_id=EXAMPLE_METADATA.object_id,
             target_bucket_id=joint_fixture.outbox_bucket,
         )
 
     # check that the file content is now in all three storage entities:
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.staging_bucket, object_id=EXAMPLE_FILE.object_id
+        bucket_id=joint_fixture.staging_bucket,
+        object_id=EXAMPLE_METADATA.object_id,
     )
     assert await joint_fixture.s3.storage.does_object_exist(
         bucket_id=joint_fixture.config.permanent_bucket,
-        object_id=EXAMPLE_FILE.object_id,
+        object_id=object_id,
     )
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_FILE.object_id
+        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
     )
 
     # check that the file content in the outbox is identical to the content in the
     # staging:
     download_url = await joint_fixture.s3.storage.get_object_download_url(
-        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_FILE.object_id
+        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_METADATA.object_id
     )
-    response = requests.get(download_url)
+    response = requests.get(download_url, timeout=60)
     response.raise_for_status()
     assert response.content == file_object.content
 
@@ -120,16 +120,16 @@ async def test_happy_journey(
         events=[
             ExpectedEvent(
                 payload={
-                    "file_id": EXAMPLE_FILE.file_id,
+                    "file_id": EXAMPLE_METADATA_BASE.file_id,
                 },
                 type_=joint_fixture.config.file_deleted_event_type,
             )
         ],
         in_topic=joint_fixture.config.file_deleted_event_topic,
     ):
-        await file_registry.delete_file(file_id=EXAMPLE_FILE.file_id)
+        await file_registry.delete_file(file_id=EXAMPLE_METADATA_BASE.file_id)
 
     assert not await joint_fixture.s3.storage.does_object_exist(
         bucket_id=joint_fixture.config.permanent_bucket,
-        object_id=EXAMPLE_FILE.object_id,
+        object_id=object_id,
     )

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -15,8 +15,6 @@
 
 """Tests typical user journeys"""
 
-import json
-
 import pytest
 import requests
 from hexkit.providers.akafka.testutils import ExpectedEvent
@@ -32,13 +30,13 @@ async def test_happy_journey(
     joint_fixture: JointFixture,  # noqa: F811, F405
     file_fixture: FileObject,  # noqa: F811
 ):
-    """Simulates a typical, successful journey for upload and download."""
+    """Simulates a typical, successful journey for upload, download, and deletion"""
 
     # place example content in the staging:
     file_object = file_fixture.copy(
         update={
-            "bucket_id": joint_fixture.config.staging_bucket,
-            "object_id": EXAMPLE_FILE.file_id,
+            "bucket_id": joint_fixture.staging_bucket,
+            "object_id": EXAMPLE_FILE.object_id,
         }
     )
     await joint_fixture.s3.populate_file_objects(file_objects=[file_object])
@@ -46,23 +44,32 @@ async def test_happy_journey(
     # register new file from the staging:
     # (And check if an event informing about the new registration has been published.)
     file_registry = await joint_fixture.container.file_registry()
+
+    event_details = EXAMPLE_FILE.dict()
+    event_details["source_object_id"] = event_details.pop("object_id")
+    event_details["source_bucket_id"] = joint_fixture.config.permanent_bucket
     async with joint_fixture.kafka.expect_events(
         events=[
             ExpectedEvent(
-                payload=json.loads(EXAMPLE_FILE.json()),
+                payload=event_details,
                 type_=joint_fixture.config.file_registered_event_type,
             )
         ],
         in_topic=joint_fixture.config.file_registered_event_topic,
     ):
-        await file_registry.register_file(file=EXAMPLE_FILE)
+        await file_registry.register_file(
+            file=EXAMPLE_FILE,
+            source_object_id=EXAMPLE_FILE.object_id,
+            source_bucket_id=joint_fixture.staging_bucket,
+        )
 
     # check that the file content is now in both the staging and the permanent storage:
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.config.staging_bucket, object_id=EXAMPLE_FILE.file_id
+        bucket_id=joint_fixture.staging_bucket, object_id=EXAMPLE_FILE.object_id
     )
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.config.permanent_bucket, object_id=EXAMPLE_FILE.file_id
+        bucket_id=joint_fixture.config.permanent_bucket,
+        object_id=EXAMPLE_FILE.object_id,
     )
 
     # request a stage to the outbox:
@@ -72,6 +79,8 @@ async def test_happy_journey(
                 payload={
                     "file_id": EXAMPLE_FILE.file_id,
                     "decrypted_sha256": EXAMPLE_FILE.decrypted_sha256,
+                    "target_object_id": EXAMPLE_FILE.object_id,
+                    "target_bucket_id": joint_fixture.outbox_bucket,
                 },
                 type_=joint_fixture.config.file_staged_event_type,
             )
@@ -79,49 +88,34 @@ async def test_happy_journey(
         in_topic=joint_fixture.config.file_staged_event_topic,
     ):
         await file_registry.stage_registered_file(
-            file_id=EXAMPLE_FILE.file_id, decrypted_sha256=EXAMPLE_FILE.decrypted_sha256
+            file_id=EXAMPLE_FILE.file_id,
+            decrypted_sha256=EXAMPLE_FILE.decrypted_sha256,
+            target_object_id=EXAMPLE_FILE.object_id,
+            target_bucket_id=joint_fixture.outbox_bucket,
         )
 
     # check that the file content is now in all three storage entities:
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.config.staging_bucket, object_id=EXAMPLE_FILE.file_id
+        bucket_id=joint_fixture.staging_bucket, object_id=EXAMPLE_FILE.object_id
     )
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.config.permanent_bucket, object_id=EXAMPLE_FILE.file_id
+        bucket_id=joint_fixture.config.permanent_bucket,
+        object_id=EXAMPLE_FILE.object_id,
     )
     assert await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.config.outbox_bucket, object_id=EXAMPLE_FILE.file_id
+        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_FILE.object_id
     )
 
     # check that the file content in the outbox is identical to the content in the
     # staging:
     download_url = await joint_fixture.s3.storage.get_object_download_url(
-        bucket_id=joint_fixture.config.outbox_bucket, object_id=EXAMPLE_FILE.file_id
+        bucket_id=joint_fixture.outbox_bucket, object_id=EXAMPLE_FILE.object_id
     )
     response = requests.get(download_url)
     response.raise_for_status()
     assert response.content == file_object.content
 
-
-@pytest.mark.asyncio
-async def test_happy_deletion(
-    joint_fixture: JointFixture,  # noqa: F811, F405
-    file_fixture: FileObject,  # noqa: F811
-):
-    """Simulates a typical, successful journey for file deletion."""
-
-    # place example content in the permanent storage bucket:
-    file_object = file_fixture.copy(
-        update={
-            "bucket_id": joint_fixture.config.permanent_bucket,
-            "object_id": EXAMPLE_FILE.file_id,
-        }
-    )
-    await joint_fixture.s3.populate_file_objects(file_objects=[file_object])
-
-    file_registry = await joint_fixture.container.file_registry()
-
-    # request a stage to the outbox:
+    # Request file deletion:
     async with joint_fixture.kafka.expect_events(
         events=[
             ExpectedEvent(
@@ -136,5 +130,6 @@ async def test_happy_deletion(
         await file_registry.delete_file(file_id=EXAMPLE_FILE.file_id)
 
     assert not await joint_fixture.s3.storage.does_object_exist(
-        bucket_id=joint_fixture.config.permanent_bucket, object_id=EXAMPLE_FILE.file_id
+        bucket_id=joint_fixture.config.permanent_bucket,
+        object_id=EXAMPLE_FILE.object_id,
     )


### PR DESCRIPTION
Add an object_id (UUID4) to decouple the IDs of files stored in S3 object storage from the file IDs contained in searchable metadata. The object id generation occurs in the file registry module upon file registration, but the file ID is still the main identifier (indexed field) for the metadata records. For validation purposes, a second pydantic model was added to contain the FileMetadata + object ID.
The only storage bucket configured now is the permanent storage bucket, the others are communicated through events. 