### PR TITLE
Use module-scope test fixtures (GSI 277)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -32,7 +32,7 @@ jobs:
         name: Verify tag format
         # format must be compatible with semantic versioning
         run: |
-          SEMVER_REGEX="^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+          SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
           if echo "${{ steps.get_version_tag.outputs.version }}" | grep -Eq "$SEMVER_REGEX"; then
             echo "Tag format is valid"
           else

--- a/.static_files
+++ b/.static_files
@@ -15,6 +15,7 @@
 scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
+scripts/__init__.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/.static_files
+++ b/.static_files
@@ -16,6 +16,7 @@ scripts/script_utils/__init__.py
 scripts/script_utils/cli.py
 
 scripts/__init__.py
+scripts/update_all.py
 scripts/license_checker.py
 scripts/get_package_name.py
 scripts/update_config_docs.py

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ We recommend using the provided Docker container.
 
 A pre-build version is available at [docker hub](https://hub.docker.com/repository/docker/ghga/internal-file-registry-service):
 ```bash
-docker pull ghga/internal-file-registry-service:0.4.0
+docker pull ghga/internal-file-registry-service:0.4.1
 ```
 
 Or you can build the container yourself from the [`./Dockerfile`](./Dockerfile):
 ```bash
 # Execute in the repo's root dir:
-docker build -t ghga/internal-file-registry-service:0.4.0 .
+docker build -t ghga/internal-file-registry-service:0.4.1 .
 ```
 
 For production-ready deployment, we recommend using Kubernetes, however,
@@ -55,7 +55,7 @@ for simple use cases, you could execute the service using docker
 on a single server:
 ```bash
 # The entrypoint is preconfigured:
-docker run -p 8080:8080 ghga/internal-file-registry-service:0.4.0 --help
+docker run -p 8080:8080 ghga/internal-file-registry-service:0.4.1 --help
 ```
 
 If you prefer not to use containers, you may install the service from source:

--- a/ifrs/__init__.py
+++ b/ifrs/__init__.py
@@ -15,4 +15,4 @@
 
 """This service acts as a registry for the internal location and representation of files."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Scripts and utils used during development or in CI pipelines."""

--- a/scripts/update_all.py
+++ b/scripts/update_all.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Run all update scripts that are present in the repository in the correct order"""
+
+try:
+    from scripts.update_template_files import main as update_template
+except ImportError:
+    pass
+else:
+    print("Pulling in updates from template repository")
+    update_template()
+
+try:
+    from scripts.update_config_docs import main as update_config
+except ImportError:
+    pass
+else:
+    print("Updating config docs")
+    update_config()
+
+try:
+    from scripts.update_openapi_docs import main as update_openapi
+except ImportError:
+    pass
+else:
+    print("Updating OpenAPI docs")
+    update_openapi()
+
+try:
+    from scripts.update_readme import main as update_readme
+except ImportError:
+    pass
+else:
+    print("Updating README")
+    update_readme()

--- a/scripts/update_template_files.py
+++ b/scripts/update_template_files.py
@@ -33,7 +33,7 @@ from pathlib import Path
 try:
     from script_utils.cli import echo_failure, echo_success, run
 except ImportError:
-    echo_failure = echo_success = print  # type: ignore
+    echo_failure = echo_success = print
 
     def run(main_fn):
         """Run main function without cli tools (typer)."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ include_package_data = True
 packages = find:
 install_requires =
     ghga-event-schemas==0.13.3
+    ghga-service-commons==0.4.3
     hexkit[mongodb,s3,akafka]==0.10.2
 python_requires = >= 3.9
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,8 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    ghga-event-schemas==0.13.1
-    hexkit[mongodb,s3,akafka]==0.10.0
+    ghga-event-schemas==0.13.3
+    hexkit[mongodb,s3,akafka]==0.10.2
 python_requires = >= 3.9
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,7 @@ console_scripts =
     ifrs = ifrs.__main__:run_forever
 
 [options.extras_require]
-dev =
 all =
-    %(dev)s
 
 
 [options.packages.find]

--- a/tests/fixtures/example_data.py
+++ b/tests/fixtures/example_data.py
@@ -15,13 +15,13 @@
 
 """Example data used for testing."""
 
-from datetime import datetime
+from ghga_service_commons.utils.utc_dates import now_as_utc
 
 from ifrs.core import models
 
 EXAMPLE_METADATA_BASE = models.FileMetadataBase(
     file_id="examplefile001",
-    upload_date=datetime.utcnow().isoformat(),
+    upload_date=now_as_utc().isoformat(),
     decryption_secret_id="some-secret-id",
     decrypted_size=64 * 1024**2,
     encrypted_part_size=16 * 1024**2,

--- a/tests/fixtures/joint.py
+++ b/tests/fixtures/joint.py
@@ -16,11 +16,7 @@
 """Join the functionality of all fixtures for API-level integration testing."""
 
 __all__ = [
-    "joint_fixture",
     "JointFixture",
-    "mongodb_fixture",
-    "s3_fixture",
-    "kafka_fixture",
     "get_joint_fixture",
 ]
 
@@ -30,9 +26,9 @@ from dataclasses import dataclass
 from typing import AsyncGenerator
 
 import pytest_asyncio
-from hexkit.providers.akafka.testutils import KafkaFixture, get_kafka_fixture
-from hexkit.providers.mongodb.testutils import MongoDbFixture, get_mongodb_fixture
-from hexkit.providers.s3.testutils import S3Fixture, get_s3_fixture
+from hexkit.providers.akafka.testutils import KafkaFixture
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+from hexkit.providers.s3.testutils import S3Fixture
 from pytest_asyncio.plugin import _ScopeName
 
 from ifrs.config import Config
@@ -108,9 +104,3 @@ async def joint_fixture_function(
 def get_joint_fixture(scope: _ScopeName = "function"):
     """Produce a joint fixture with desired scope"""
     return pytest_asyncio.fixture(joint_fixture_function, scope=scope)
-
-
-joint_fixture = get_joint_fixture()
-mongodb_fixture = get_mongodb_fixture()
-kafka_fixture = get_kafka_fixture()
-s3_fixture = get_s3_fixture()

--- a/tests/fixtures/module_scope_fixtures.py
+++ b/tests/fixtures/module_scope_fixtures.py
@@ -24,14 +24,12 @@ from hexkit.providers.testing.utils import get_event_loop
 from tests.fixtures.joint import JointFixture, get_joint_fixture
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(autouse=True)
 async def reset_state(joint_fixture: JointFixture):  # noqa: F811
     """Clear joint_fixture state before and after tests that use this fixture.
 
     This is a function-level fixture because it needs to run in each test.
     """
-    await joint_fixture.reset_state()
-    yield
     await joint_fixture.reset_state()
 
 

--- a/tests/fixtures/module_scope_fixtures.py
+++ b/tests/fixtures/module_scope_fixtures.py
@@ -1,0 +1,42 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contains module-scoped fixtures"""
+
+import pytest_asyncio
+from hexkit.providers.akafka.testutils import get_kafka_fixture
+from hexkit.providers.mongodb.testutils import get_mongodb_fixture
+from hexkit.providers.s3.testutils import get_s3_fixture
+from hexkit.providers.testing.utils import get_event_loop
+
+from tests.fixtures.joint import JointFixture, get_joint_fixture
+
+
+@pytest_asyncio.fixture
+async def reset_state(joint_fixture: JointFixture):  # noqa: F811
+    """Clear joint_fixture state before and after tests that use this fixture.
+
+    This is a function-level fixture because it needs to run in each test.
+    """
+    await joint_fixture.reset_state()
+    yield
+    await joint_fixture.reset_state()
+
+
+event_loop = get_event_loop("module")
+mongodb_fixture = get_mongodb_fixture("module")
+kafka_fixture = get_kafka_fixture("module")
+s3_fixture = get_s3_fixture("module")
+joint_fixture = get_joint_fixture("module")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -17,17 +17,24 @@
 
 
 import pytest
-from hexkit.providers.s3.testutils import file_fixture  # noqa: F401
-from hexkit.providers.s3.testutils import FileObject
+from hexkit.providers.s3.testutils import FileObject, file_fixture  # noqa: F401
 
 from ifrs.ports.inbound.file_registry import FileRegistryPort
 from tests.fixtures.example_data import EXAMPLE_METADATA, EXAMPLE_METADATA_BASE
-from tests.fixtures.joint import *  # noqa: F403
+from tests.fixtures.module_scope_fixtures import (  # noqa: F401
+    JointFixture,
+    event_loop,
+    joint_fixture,
+    kafka_fixture,
+    mongodb_fixture,
+    reset_state,
+    s3_fixture,
+)
 
 
 @pytest.mark.asyncio
 async def test_register_with_empty_staging(
-    joint_fixture: JointFixture,  # noqa: F811, F405
+    joint_fixture: JointFixture, reset_state  # noqa: F811
 ):
     """Test registration of a file when the file content is missing from the staging."""
 
@@ -42,8 +49,9 @@ async def test_register_with_empty_staging(
 
 @pytest.mark.asyncio
 async def test_reregistration(
-    joint_fixture: JointFixture,  # noqa: F811, F405
+    joint_fixture: JointFixture,  # noqa: F811
     file_fixture: FileObject,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Test the re-registration of a file with identical metadata (should not result in
     an exception)."""
@@ -90,8 +98,9 @@ async def test_reregistration(
 
 @pytest.mark.asyncio
 async def test_reregistration_with_updated_metadata(
-    joint_fixture: JointFixture,  # noqa: F811, F405
+    joint_fixture: JointFixture,  # noqa: F811
     file_fixture: FileObject,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Check that a re-registration of a file with updated metadata fails with the
     expected exception."""
@@ -139,7 +148,9 @@ async def test_reregistration_with_updated_metadata(
 
 
 @pytest.mark.asyncio
-async def test_stage_non_existing_file(joint_fixture: JointFixture):  # noqa: F811, F405
+async def test_stage_non_existing_file(
+    joint_fixture: JointFixture, reset_state  # noqa: F811
+):
     """Check that requesting to stage a non-registered file fails with the expected
     exception."""
 
@@ -155,8 +166,9 @@ async def test_stage_non_existing_file(joint_fixture: JointFixture):  # noqa: F8
 
 @pytest.mark.asyncio
 async def test_stage_checksum_missmatch(
-    joint_fixture: JointFixture,  # noqa: F811, F405
+    joint_fixture: JointFixture,  # noqa: F811
     file_fixture: FileObject,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Check that requesting to stage a registered file to the outbox by specifying the
     wrong checksum fails with the expected exception."""
@@ -189,7 +201,8 @@ async def test_stage_checksum_missmatch(
 
 @pytest.mark.asyncio
 async def test_storage_db_inconsistency(
-    joint_fixture: JointFixture,  # noqa: F811, F405
+    joint_fixture: JointFixture,  # noqa: F811
+    reset_state,  # noqa: F811
 ):
     """Check that an inconsistency between the database and the storage, whereby the
     database contains a file metadata registration but the storage is missing the

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -33,9 +33,7 @@ from tests.fixtures.module_scope_fixtures import (  # noqa: F401
 
 
 @pytest.mark.asyncio
-async def test_register_with_empty_staging(
-    joint_fixture: JointFixture, reset_state  # noqa: F811
-):
+async def test_register_with_empty_staging(joint_fixture: JointFixture):  # noqa: F811
     """Test registration of a file when the file content is missing from the staging."""
 
     file_registry = await joint_fixture.container.file_registry()
@@ -51,7 +49,6 @@ async def test_register_with_empty_staging(
 async def test_reregistration(
     joint_fixture: JointFixture,  # noqa: F811
     file_fixture: FileObject,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Test the re-registration of a file with identical metadata (should not result in
     an exception)."""
@@ -100,7 +97,6 @@ async def test_reregistration(
 async def test_reregistration_with_updated_metadata(
     joint_fixture: JointFixture,  # noqa: F811
     file_fixture: FileObject,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Check that a re-registration of a file with updated metadata fails with the
     expected exception."""
@@ -148,9 +144,7 @@ async def test_reregistration_with_updated_metadata(
 
 
 @pytest.mark.asyncio
-async def test_stage_non_existing_file(
-    joint_fixture: JointFixture, reset_state  # noqa: F811
-):
+async def test_stage_non_existing_file(joint_fixture: JointFixture):  # noqa: F811
     """Check that requesting to stage a non-registered file fails with the expected
     exception."""
 
@@ -168,7 +162,6 @@ async def test_stage_non_existing_file(
 async def test_stage_checksum_missmatch(
     joint_fixture: JointFixture,  # noqa: F811
     file_fixture: FileObject,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Check that requesting to stage a registered file to the outbox by specifying the
     wrong checksum fails with the expected exception."""
@@ -202,7 +195,6 @@ async def test_stage_checksum_missmatch(
 @pytest.mark.asyncio
 async def test_storage_db_inconsistency(
     joint_fixture: JointFixture,  # noqa: F811
-    reset_state,  # noqa: F811
 ):
     """Check that an inconsistency between the database and the storage, whereby the
     database contains a file metadata registration but the storage is missing the

--- a/tests/test_typical_journey.py
+++ b/tests/test_typical_journey.py
@@ -22,7 +22,15 @@ from hexkit.providers.s3.testutils import file_fixture  # noqa: F401
 from hexkit.providers.s3.testutils import FileObject
 
 from tests.fixtures.example_data import EXAMPLE_METADATA, EXAMPLE_METADATA_BASE
-from tests.fixtures.joint import *  # noqa: F403
+from tests.fixtures.module_scope_fixtures import (  # noqa: F401
+    JointFixture,
+    event_loop,
+    joint_fixture,
+    kafka_fixture,
+    mongodb_fixture,
+    reset_state,
+    s3_fixture,
+)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Same treatment as the UCS - module fixtures in `module_scope_fixtures.py`. Typical journey only has one test, so I didn't touch that.
There was an issue where, from what I could tell, attempts to delete kafka topics during the `reset_state` in the last test were slightly delayed, causing the container to start teardown beforehand and hang. I tried various fixes but in the end what worked was adding `await sleep(2)` after the joint fixture's `yield`.